### PR TITLE
Fix #2

### DIFF
--- a/src/main/java/net/werdei/zoomglass/client/SlotSwapper.java
+++ b/src/main/java/net/werdei/zoomglass/client/SlotSwapper.java
@@ -4,9 +4,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
 import net.minecraft.screen.slot.SlotActionType;
-import net.minecraft.text.Text;
 import net.minecraft.util.Hand;
 
 public class SlotSwapper
@@ -39,7 +37,14 @@ public class SlotSwapper
     {
         if (isSwapped()) return;
 
-        var itemSlotId = client.player.getInventory().getSlotWithStack(new ItemStack(item));
+        var itemSlotId = -1;
+        var items = client.player.getInventory().main;
+        for (int i = 0; i < items.size() && itemSlotId == -1; ++i)
+        {
+            if (!items.get(i).isEmpty() && items.get(i).isOf(item))
+                itemSlotId = i;
+        }
+
         if (itemSlotId == -1)
             throw new NoItemException();
 


### PR DESCRIPTION
## Description
Makes the mod work with any spyglass, not just default nbt.

## Proposed changes
- Replaced `PlayerInventory#getSlotWithStack` to my own loop based off of its code. It simply loops through all the ItemStacks and checks if they are not empty and "of" the Spyglass Item. 
- I'm not used to your code style so if there are any problems let me know and I will address them!

## Related Issues
#2 

## Testing
I have not done *extensive* testing, I simply tested with a normal and then renamed spyglass and both worked accordingly (in the hotbar and in the inventory). If you want me to do more or want to do more yourself just lmk!